### PR TITLE
Obsolete extention method AddAzureADB2CBearer in Startup.cs

### DIFF
--- a/jitbox/JitBox.Api/Startup.cs
+++ b/jitbox/JitBox.Api/Startup.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.AzureADB2C.UI;
+using Microsoft.Identity.Web;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,8 +31,9 @@ namespace JitBox.Api
             services.AddCors();
             IdentityModelEventSource.ShowPII = true;
 
-            services.AddAuthentication(AzureADB2CDefaults.BearerAuthenticationScheme)
-                .AddAzureADB2CBearer(options => Configuration.Bind("AzureAdB2C", options));
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+             .AddMicrosoftIdentityWebApi(Configuration, configSectionName: "AzureAdB2C");
+
             services.AddControllers();
         }
 


### PR DESCRIPTION
Cosmetic change: Extention method AddAzureADB2CBearer is obsolete. It should be replaced with AddMicrosoftIdentityWebApi.

Thank you for a nice example  Azure AD B2C